### PR TITLE
feat: Add support for legagy Angular v15 theming.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v9.0.0 (TBD)
+
+### Changed
+
+-   Updated to Angular 15 for building the library. The lib will use the legacy Material components (not the MDC Web).
+
 ## v8.0.0 (November 21, 2022)
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@brightlayer-ui/angular-themes",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "8.0.0",
+    "version": "9.0.0",
     "description": "Angular themes for Brightlayer UI applications",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",
@@ -21,7 +21,9 @@
     },
     "watch": {
         "copy-to-showcase": {
-            "patterns": ["**"],
+            "patterns": [
+                "**"
+            ],
             "extensions": "scss",
             "ignore": "demos"
         }
@@ -55,13 +57,13 @@
         "@fontsource/open-sans": "^4.1.0"
     },
     "devDependencies": {
-        "@angular/material": "^15.1.1",
+        "@angular/material": "^15.0.0",
         "@brightlayer-ui/prettier-config": "^1.0.3",
         "npm-license-crawler": "^0.2.1",
         "npm-watch": "^0.11.0",
         "prettier": "^2.7.1"
     },
     "peerDependencies": {
-        "@angular/material": "^14.0.0"
+        "@angular/material": "^15.0.0"
     }
 }

--- a/theme-bases.scss
+++ b/theme-bases.scss
@@ -51,7 +51,7 @@ $blui-blue-warn: mat.define-palette(blui.$blui-red);
     $theme: blui-light-theme($primary, $accent, $warn);
     @include sharedConfig();
 
-    @include mat.all-component-themes($theme);
+    @include mat.all-legacy-component-themes($theme);
     @include blui-component-theme.blui-components-theme($theme);
     @include blueTheme.bluetheme($theme);
 }
@@ -93,7 +93,7 @@ $blui-blue-dark-warn: mat.define-palette(blui.$blui-red, 200);
     $theme: blui-dark-theme($primary, $accent, $warn);
     @include sharedConfig();
 
-    @include mat.all-component-themes($theme);
+    @include mat.all-legacy-component-themes($theme);
     @include blui-component-theme.blui-components-theme($theme);
     @include darkTheme.darktheme($theme);
 }
@@ -104,7 +104,7 @@ $blui-blue-dark-warn: mat.define-palette(blui.$blui-red, 200);
 
 @mixin coreTypography() {
     // Custom Typography Sizes & Weights
-    $custom-typography: mat.define-typography-config(
+    $custom-typography: mat.define-legacy-typography-config(
         $font-family: '"Open Sans", Arial, Helvetica, sans-serif;',
         $display-4: mat.define-typography-level(6rem, 1.167, 300),
         $display-2: mat.define-typography-level(3rem, 1.167, 400),
@@ -126,5 +126,6 @@ $blui-blue-dark-warn: mat.define-palette(blui.$blui-red, 200);
     ** NOTE: material theme will use our Brightlayer UI custom typography
     ** There is currently not a way to specify different custom fonts for different themes
     */
-    @include mat.core($custom-typography);
+    @include mat.all-legacy-component-typographies($custom-typography);
+    @include mat.core();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@angular/material@^15.1.1":
-  version "15.1.1"
-  resolved "https://registry.npmjs.org/@angular/material/-/material-15.1.1.tgz"
-  integrity sha512-QhyTJv9CnimXKXb4LCH93ovJVAdnoHyElwspl80PcfAV/6A6VrRQAflFoul0WL4WPrV50DG7TWYiEwHPpblbCw==
+"@angular/material@15":
+  version "15.2.0"
+  resolved "https://registry.yarnpkg.com/@angular/material/-/material-15.2.0.tgz#7613ebecf0e92569c17b4bbcd539f2f46d8e8b6e"
+  integrity sha512-3Y6MMureeqFx5mzVnLuWrm+MXtTBAZGq0cPNcS3HUSv4gpKE3gSE0b3I4c/jFF5tcS2eQKNkU/HDvSFrYz8/iA==
   dependencies:
     "@material/animation" "15.0.0-canary.684e33d25.0"
     "@material/auto-init" "15.0.0-canary.684e33d25.0"


### PR DESCRIPTION
Since the move to v15, Angular supports 2 type of components : 

* The new MDC implementation
* The legacy one which were only one until v14. 

The commit adds the support of theming for Angular legacy components only.

Maybe it should be discussed if this lib should also directly provide support for non-legacy theming.  

Fixes: #143 