### PR TITLE
Fix drawer header color styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v8.1.0 (unreleased)
 
+### Fixed
+
+-   Fixed `<blui-drawer-header>` `color` prop issue ([#152](https://github.com/etn-ccis/blui-angular-themes/issues/152)).
+
 ### Added
 
 -   Support for CSS Custom properties customization.

--- a/_blui-component-theme.scss
+++ b/_blui-component-theme.scss
@@ -107,9 +107,6 @@
         .blui-drawer-nav-group .mat-list-base {
             color: map-get($foreground, text);
         }
-        .blui-drawer-header-content.mat-toolbar {
-            background-color: map-get($primary, 500);
-        }
         .blui-drawer-nav-item-active-highlight {
             background-color: map-get($primary, 500);
         }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@brightlayer-ui/angular-themes",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "8.1.0-beta.0",
+    "version": "8.1.0-beta.1",
     "description": "Angular themes for Brightlayer UI applications",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",
@@ -21,7 +21,9 @@
     },
     "watch": {
         "copy-to-showcase": {
-            "patterns": ["**"],
+            "patterns": [
+                "**"
+            ],
             "extensions": "scss",
             "ignore": "demos"
         }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #152.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Fix drawer header color styles
- This will publish a beta package so this can be further tested in the developer documentation site

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- clone repo
- `yarn && yarn start`
- update the main drawer header in the showcase to render in all 3 background colors available via the color prop

e.g.,

BLUE[500]:
`<blui-drawer-header title="Showcase App" class="test-background-image" color="primary">`
BLUE[700]:
`<blui-drawer-header title="Showcase App" class="test-background-image" color="accent">`
RED[500]:
`<blui-drawer-header title="Showcase App" class="test-background-image" color="warn">`
