### PR TITLE
78 matselect icon not vertically aligned issue is fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 -   Fixed `<blui-drawer-header>` `color` prop issue ([#152](https://github.com/etn-ccis/blui-angular-themes/issues/152)).
+-   Fixed dropdown arrow not vertically aligned issue in `<mat-select>` ([#78](https://github.com/etn-ccis/blui-angular-themes/issues/78)).
 
 ### Added
 

--- a/_common.scss
+++ b/_common.scss
@@ -258,10 +258,6 @@
             .mat-form-field-subscript-wrapper {
                 padding: $ltrOutlinePadding;
             }
-            &.mat-form-field-should-float .mat-form-field-infix {
-                margin-top: -0.125rem;
-                margin-bottom: 0.125rem;
-            }
             .mat-form-field-suffix,
             .mat-form-field-prefix {
                 margin-bottom: 0.25rem;
@@ -277,9 +273,6 @@
             .mat-form-field-suffix,
             .mat-form-field-prefix {
                 margin-bottom: 0.75rem;
-            }
-            .mat-form-field-infix {
-                padding-top: 0.125rem;
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@brightlayer-ui/angular-themes",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "8.1.0-beta.1",
+    "version": "8.1.0",
     "description": "Angular themes for Brightlayer UI applications",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #78 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Clean overriding class to fix this issue
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
![image](https://user-images.githubusercontent.com/13012853/225569957-1465aff9-9a2b-431f-af50-0fd972e919c5.png)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn test

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
