### PR TITLE
79 dark theme blui drawer header should use white color issue is fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 -   Fixed `<blui-drawer-header>` `color` prop issue ([#152](https://github.com/etn-ccis/blui-angular-themes/issues/152)).
+-   Fixed Dark theme `<blui-drawer-header>` text and icon color should use white50 issue ([#79](https://github.com/etn-ccis/blui-angular-themes/issues/79)).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 -   Fixed `<blui-drawer-header>` `color` prop issue ([#152](https://github.com/etn-ccis/blui-angular-themes/issues/152)).
--   Fixed Dark theme `<blui-drawer-header>` text and icon color should use white50 issue ([#79](https://github.com/etn-ccis/blui-angular-themes/issues/79)).
+-   Fixed Dark theme `<blui-drawer-header>` text and icon color issue ([#79](https://github.com/etn-ccis/blui-angular-themes/issues/79)).
 
 ### Added
 

--- a/_darkTheme.scss
+++ b/_darkTheme.scss
@@ -453,6 +453,12 @@
     .mat-toolbar {
         color: map-get($foreground, text);
         background-color: map-get(blui.$blui-darkBlack, 100);
+        .blui-drawer-header-title {
+            color: map-get(blui.$blui-white, 50);
+        }
+        .mat-icon-button {
+            color: map-get(blui.$blui-white, 50);
+        }
         &.mat-primary {
             background-color: map-get(blui.$blui-black, 800);
             color: map-get(blui.$blui-black, 50);

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "@brightlayer-ui/prettier-config": "^1.0.3",
         "npm-license-crawler": "^0.2.1",
         "npm-watch": "^0.11.0",
-        "prettier": "^2.8.4"
+        "prettier": "^2.7.1"
     },
     "peerDependencies": {
         "@angular/material": "^14.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@brightlayer-ui/angular-themes",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "8.1.0-beta.1",
+    "version": "8.1.0",
     "description": "Angular themes for Brightlayer UI applications",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",
@@ -61,7 +61,7 @@
         "@brightlayer-ui/prettier-config": "^1.0.3",
         "npm-license-crawler": "^0.2.1",
         "npm-watch": "^0.11.0",
-        "prettier": "^2.7.1"
+        "prettier": "^2.8.4"
     },
     "peerDependencies": {
         "@angular/material": "^14.0.0"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #79  .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Changed the blui-drawer-header text and icon color to white 50
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
<img width="643" alt="dark-theme-toolbar" src="https://user-images.githubusercontent.com/13012853/226847943-741dff04-ed98-423c-a3d0-2a7403e5d403.png">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn test

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
