### PR TITLE
133 blui-inline doesnot work with inline svg icons issue fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 -   Fixed `<blui-drawer-header>` `color` prop issue ([#152](https://github.com/etn-ccis/blui-angular-themes/issues/152)).
+-   Fixed `<blui-inline>` doesnot work with inline svg icons issue ([#133](https://github.com/etn-ccis/blui-angular-themes/issues/133)).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 -   Fixed `<blui-drawer-header>` `color` prop issue ([#152](https://github.com/etn-ccis/blui-angular-themes/issues/152)).
--   Fixed `<blui-inline>` doesnot work with inline svg icons issue ([#133](https://github.com/etn-ccis/blui-angular-themes/issues/133)).
+-   Fixed `<blui-inline>` does not work with inline svg icons issue ([#133](https://github.com/etn-ccis/blui-angular-themes/issues/133)).
 
 ### Added
 

--- a/_common.scss
+++ b/_common.scss
@@ -156,6 +156,7 @@
             align-items: center;
             justify-content: center;
             .mat-icon {
+                display: flex;
                 height: 1.125rem;
                 width: 1.125rem;
                 font-size: 1.125rem;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@brightlayer-ui/angular-themes",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "8.1.0-beta.1",
+    "version": "8.1.0",
     "description": "Angular themes for Brightlayer UI applications",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #133  .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Modified mat-icon SCSS class to fixed the svg icon issue
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
<img width="405" alt="Screenshot 2023-03-22 at 4 08 23 PM" src="https://user-images.githubusercontent.com/13012853/226880766-fb791191-9376-487e-90e9-7c72726530ef.png">
<img width="405" alt="Screenshot 2023-03-22 at 4 09 25 PM" src="https://user-images.githubusercontent.com/13012853/226880792-c07e20e8-563f-4f50-8700-5e3c8da4b985.png">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn test

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
