### PR TITLE
137-Remove edge show password icon issue is fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 -   Fixed chip mixin to use correct accent color issue ([#72](https://github.com/etn-ccis/blui-angular-themes/issues/72)).
 -   Fixed `<blui-inline>` does not work with inline svg icons issue ([#133](https://github.com/etn-ccis/blui-angular-themes/issues/133)).
 -   Fixed Dark theme `<blui-drawer-header>` text and icon color issue ([#79](https://github.com/etn-ccis/blui-angular-themes/issues/79)).
--   Fixed Remove show password icon in the Edge browser issue ([#137](https://github.com/etn-ccis/blui-angular-workflows/issues/137)).
+-   Fixed an issue where password field displays two show password icons on the Edge browser ([#168](https://github.com/etn-ccis/blui-angular-themes/issues/168)).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 -   Fixed chip mixin to use correct accent color issue ([#72](https://github.com/etn-ccis/blui-angular-themes/issues/72)).
 -   Fixed `<blui-inline>` does not work with inline svg icons issue ([#133](https://github.com/etn-ccis/blui-angular-themes/issues/133)).
 -   Fixed Dark theme `<blui-drawer-header>` text and icon color issue ([#79](https://github.com/etn-ccis/blui-angular-themes/issues/79)).
--   Fixed an issue where password field displays two show password icons on the Edge browser ([#168](https://github.com/etn-ccis/blui-angular-themes/issues/168)).
+-   Fixed an issue where the browser default password reveal button collides with any matSuffix input icon provided ([#168](https://github.com/etn-ccis/blui-angular-themes/issues/168)).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 -   Fixed chip mixin to use correct accent color issue ([#72](https://github.com/etn-ccis/blui-angular-themes/issues/72)).
 -   Fixed `<blui-inline>` does not work with inline svg icons issue ([#133](https://github.com/etn-ccis/blui-angular-themes/issues/133)).
 -   Fixed Dark theme `<blui-drawer-header>` text and icon color issue ([#79](https://github.com/etn-ccis/blui-angular-themes/issues/79)).
--   Fixed Remove Edge show password icon for Blui-angular-workflow repo issue ([#137](https://github.com/etn-ccis/blui-angular-workflows/issues/137)).
+-   Fixed Remove show password icon in the Edge browser issue ([#137](https://github.com/etn-ccis/blui-angular-workflows/issues/137)).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   Fixed chip mixin to use correct accent color issue ([#72](https://github.com/etn-ccis/blui-angular-themes/issues/72)).
 -   Fixed `<blui-inline>` does not work with inline svg icons issue ([#133](https://github.com/etn-ccis/blui-angular-themes/issues/133)).
 -   Fixed Dark theme `<blui-drawer-header>` text and icon color issue ([#79](https://github.com/etn-ccis/blui-angular-themes/issues/79)).
+-   Fixed Remove Edge show password icon for Blui-angular-workflow repo issue ([#137](https://github.com/etn-ccis/blui-angular-workflows/issues/137)).
 
 ### Added
 

--- a/mixins/input-field.scss
+++ b/mixins/input-field.scss
@@ -4,7 +4,9 @@
     input {
         font-family: 'Open Sans';
     }
-
+    input::-ms-reveal {
+        display: none;
+    }
     .mat-form-field {
         &.mat-primary {
             @include colored-input-styles($primaryPalette);


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes 168(https://github.com/etn-ccis/blui-angular-themes/issues/168)-Remove edge show password icon (blui-angular-workflow repository issue fixed in this repo). 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- updated blui-mat-form-field input class to resolved this issue
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
![image](https://user-images.githubusercontent.com/13012853/229276681-9f3cce49-d243-467c-a8db-8dfa6a43504a.png)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn test

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
