### PR TITLE
Set The Inactive Tab Text Color to Black

### DIFF
--- a/_blueTheme.scss
+++ b/_blueTheme.scss
@@ -381,7 +381,7 @@
     @include button-toggle.blui-mat-button-toggle($buttonToggleDefault, $buttonToggleOutline, $buttonToggleFilled);
 
     /* Tabs */
-    $tabText: map-get($primary, 500);
+    $tabText: map-get(blui.$blui-black, 500);
     $tabBackground: map-get($foreground, onPrimary);
     $tabActiveText: map-get($primary, 500);
     $tabActiveBackground: map-get($foreground, onPrimary);


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- The inactive tab text color should be black

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- After change
![1](https://github.com/etn-ccis/blui-angular-themes/assets/143647302/8108a8c0-c7a9-4919-9064-a433eeb81643)

- Original
![2](https://github.com/etn-ccis/blui-angular-themes/assets/143647302/3e4f9fdf-6090-4d4e-8389-42eefce669b9)

