### PR TITLE
Inactive tabs should use foreground color instead of primary color.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 -   Fixed Angular 15 themes should match the legacy themes issue ([#156](https://github.com/etn-ccis/blui-angular-themes/issues/156)).
+-   Fixed inactive tabs should use foreground color instead of primary color issue ([#200](https://github.com/etn-ccis/blui-angular-themes/issues/200)).
 
 ## v9.0.0 (July 3, 2023)
 

--- a/_blueTheme.scss
+++ b/_blueTheme.scss
@@ -381,7 +381,7 @@
     @include button-toggle.blui-mat-button-toggle($buttonToggleDefault, $buttonToggleOutline, $buttonToggleFilled);
 
     /* Tabs */
-    $tabText: map-get(blui.$blui-black, 500);
+    $tabText: map-get($foreground, 500);
     $tabBackground: map-get($foreground, onPrimary);
     $tabActiveText: map-get($primary, 500);
     $tabActiveBackground: map-get($foreground, onPrimary);

--- a/_blueTheme.scss
+++ b/_blueTheme.scss
@@ -381,7 +381,7 @@
     @include button-toggle.blui-mat-button-toggle($buttonToggleDefault, $buttonToggleOutline, $buttonToggleFilled);
 
     /* Tabs */
-    $tabText: map-get($primary, 500);
+    $tabText: map-get(blui.$blui-black, 500);
     $tabBackground: map-get($foreground, onPrimary);
     $tabActiveText: map-get($primary, 500);
     $tabActiveBackground: map-get($foreground, onPrimary);


### PR DESCRIPTION
Fixes #200 .

**Changes proposed in this Pull Request:**

- The inactive tab text color should be black

**Screenshots**

![](https://user-images.githubusercontent.com/143647302/264748107-8108a8c0-c7a9-4919-9064-a433eeb81643.PNG)
